### PR TITLE
Fixes for installing on 2017-01-11-raspbian-jessie-lite.img on Raspberry Pi 3B

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ sudo mkinitramfs -v -o /boot/initramfs.gz # creates keys and directories for dro
 sudo vi /etc/initramfs-tools/initramfs.conf # add DROPBEAR=y and CRYPTSETUP=y, does not enforce including cryptsetup!?
 sudo vi /usr/share/initramfs-tools/hooks/cryptroot # enforce setup="yes" so that cryptsetup is included in initramfs
 sudo vi /etc/initramfs-tools/root/.ssh/authorized_keys # add your ssh-pubkeys
+sudo vi /usr/share/initramfs-tools/scripts/local-top/ # Fix https://bugs.launchpad.net/ubuntu/+source/cryptsetup/+bug/595648/comments/5 like described in the link by editing this by hand. Starting at line 288 comment out the first branch of the if.
 sudo mkinitramfs -v -o /boot/initramfs.gz # again so that the settings are applied, check output for dropbear and cryptsetup
 sudo vi /boot/config.txt # add: initramfs initramfs.gz followkernel
 sudo reboot # test reboot
@@ -39,7 +40,7 @@ sudo e2fsck /dev/mapper/raspi_crypt
 mkdir /tmp/piroot
 sudo mount /dev/mapper/raspi_crypt /tmp/piroot/
 sudo mount /dev/sdX1 /tmp/piroot/boot/
-sudo vim /tmp/piroot/boot/cmdline.txt # Change root=/dev/mmcblk0p2 to root=/dev/mapper/raspi_crypt and add cryptdevice=/dev/mmcblk0p2:raspi_crypt
+sudo vim /tmp/piroot/boot/cmdline.txt # Change root=/dev/mmcblk0p2 to root=/dev/mapper/raspi_crypt and add cryptdevice=/dev/mmcblk0p2:raspi_crypt and add ip=:::::eth0:dhcp
 sudo vim /tmp/piroot/etc/fstab # change /dev/mmcblk0p2 to /dev/mapper/raspi_crypt
 sudo vim /tmp/piroot/etc/crypttab # add raspi_crypt /dev/mmcblk0p2 none luks
 sudo umount /tmp/piroot/boot/ /tmp/piroot/


### PR DESCRIPTION
Two fixes I needed to do to get it all to work.
First fix for bug https://bugs.launchpad.net/ubuntu/+source/cryptsetup/+bug/595648 as described in the fifth comment. The actual file was slightly different compared to what was described in the link, but exactly as described there I needed to comment out the if branch of the if else (make sure to remember to also comment out the fi):
```
#if [ -x /bin/plymouth ] && plymouth --ping; then
                        #       cryptkeyscript="plymouth ask-for-password --prompt"
                        #       # Plymouth will add a : if it is a non-graphical prompt
                        #       cryptkey="Please unlock disk $diskname"
                        #else
                                cryptkeyscript="/lib/cryptsetup/askpass"
                                cryptkey="Please unlock disk $diskname: "
                        #fi
```

Second: My Pi would successfully run the initramfs, but not connect to the network. I needed to add the `ip=:::::eth0:dhcp` kernel option to `/boot/cmdline.txt` for it to work.